### PR TITLE
Refactor pain for overburden, fix disease rate mod

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5319,8 +5319,9 @@ void Character::get_sick()
         return;
     }
 
+
     // Normal people get sick about 2-4 times/year.
-    int base_diseases_per_year = 3 + base_disease_rate_modifier;
+    float base_diseases_per_year = 3.0f + mutation_value( "base_disease_rate_modifier" );
 
     // This check runs once every 30 minutes, so double to get hours, *24 to get days.
     const int checks_per_year = 2 * 24 * 365;
@@ -7589,14 +7590,17 @@ void Character::burn_move_stamina( int moves )
     burn_ratio *= move_mode->stamina_mult();
     mod_stamina( -( ( moves * burn_ratio ) / 100.0 ) * stamina_move_cost_modifier() );
     add_msg( m_debug, "Stamina burn: %d", -( ( moves * burn_ratio ) / 100 ) );
-    // Chance to suffer pain if overburden and stamina runs out or has trait BADBACK
-    // Starts at 1 in 25, goes down by 5 for every 50% more carried
-    if( ( current_weight > max_weight ) && ( has_trait( trait_BADBACK ) || ( current_weight > max_weight ) && ( has_trait( trait_MUSCLEATROPHY ) || get_stamina() == 0 ) &&
-        one_in( 35 - 5 * current_weight / ( max_weight / 2 ) ) ) {
-        add_msg_if_player( m_bad, _( "Your body strains under the weight!" ) );
-        // 1 more pain for every 800 grams more (5 per extra STR needed)
-        if( ( ( current_weight - max_weight ) / 800_gram > get_pain() && get_pain() < 100 ) ) {
-            mod_pain( 1 );
+
+    // If stamina runs out, or if we have BADBACK or MUSCLEATROPHY trait,
+    // there is a chance to suffer pain when overburdened.
+    if( get_stamina() == 0 || has_trait( trait_BADBACK ) || has_trait( trait_MUSCLEATROPHY ) ) {
+        // Chance of pain starts at 1 in 25, goes down by 5 for every 50% more carried
+        int odds_against_pain = 35 - 5 * current_weight / ( max_weight / 2 );
+        if( current_weight > max_weight && one_in( odds_against_pain ) ) {
+            // 1 more pain for every 800 grams more (5 per extra STR needed)
+            if( ( ( current_weight - max_weight ) / 800_gram > get_pain() && get_pain() < 100 ) ) {
+                mod_pain( 1 );
+            }
         }
     }
 }

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -191,6 +191,7 @@ struct mutation_branch {
         float attackcost_modifier = 1.0f;
         float max_stamina_modifier = 1.0f;
         float weight_capacity_modifier = 1.0f;
+        float base_disease_rate_modifier = 0;
         float hearing_modifier = 1.0f;
         float movecost_swim_modifier = 1.0f;
         float noise_modifier = 1.0f;

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -416,6 +416,7 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "attackcost_modifier", attackcost_modifier, 1.0f );
     optional( jo, was_loaded, "max_stamina_modifier", max_stamina_modifier, 1.0f );
     optional( jo, was_loaded, "weight_capacity_modifier", weight_capacity_modifier, 1.0f );
+    optional( jo, was_loaded, "base_disease_rate_modifier", base_disease_rate_modifier, 0.0f );
     optional( jo, was_loaded, "hearing_modifier", hearing_modifier, 1.0f );
     optional( jo, was_loaded, "noise_modifier", noise_modifier, 1.0f );
     optional( jo, was_loaded, "temperature_speed_modifier", temperature_speed_modifier, 0.0f );

--- a/tests/char_stamina_test.cpp
+++ b/tests/char_stamina_test.cpp
@@ -360,6 +360,18 @@ TEST_CASE( "burning stamina when overburdened may cause pain", "[stamina][burn][
                 CHECK( pain_after > pain_before );
             }
         }
+
+        WHEN( "they have muscle atrophy" ) {
+            dummy.toggle_trait( trait_id( "MUSCLEATROPHY" ) );
+            REQUIRE( dummy.has_trait( trait_id( "MUSCLEATROPHY" ) ) );
+
+            THEN( "they feel pain when carrying too much weight" ) {
+                pain_before = dummy.get_pain();
+                dummy.burn_move_stamina( to_moves<int>( 1_turns ) );
+                pain_after = dummy.get_pain();
+                CHECK( pain_after > pain_before );
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This PR is a patch of your `trait_additions` branch with the new declarations I mentioned, along with a refactoring of that ugly conditional expression in `burn_move_stamina`. Feel free to merge it into your branch, or just pick out the pieces you want.

The stamina burn with BADBACK was something we already had a test case on, so it was easy to also add another for the MUSCLEATROPHY trait. After compiling, you can run the test with `tests/cata_test [stamina][pain]`
